### PR TITLE
add new form creation,add in highlight.js functionality

### DIFF
--- a/class-05-new-article-creation/lecture/starter-code/scripts/articleView.js
+++ b/class-05-new-article-creation/lecture/starter-code/scripts/articleView.js
@@ -63,25 +63,40 @@ articleView.setTeasers = function() {
 };
 
 articleView.initNewArticlePage = function() {
-  // TODO: Ensure the main .tab-content area is revealed. We might add more tabs later.
+  // TODO Done: Ensure the main .tab-content area is revealed. We might add more tabs later.
+  $('.tab-content').show();
 
-  // TODO: The new articles we create will be copy/pasted into our source data file.
+  // TODO Done: The new articles we create will be copy/pasted into our source data file.
   // Set up this "export" functionality. We can hide it for now, and show it once we have data to export.
-
-  // TODO: Add an event handler to update the preview and the export field if any inputs change.
+  $('#export-field').hide();
+  // TODO Done: Add an event handler to update the preview and the export field if any inputs change.
+  $('#new-form').on('change', 'input, textarea', articleView.create);
 };
 
 articleView.create = function() {
-  // TODO: Set up a var to hold the new article we are creating.
+  // TODO Done: Set up a var to hold the new article we are creating.
   // Clear out the #articles element, so we can put in the updated preview
+  var articlePreview;
+  $('#articles').empty();
+  // TODO Done: Instantiate an article based on what's in the form fields:
+  articlePreview = new Article ({
+    title: $('#article-title').val(),
+    body: $('#article-body').val(),
+    author: $('#article-author').val(),
+    authorUrl: $('#article-author-url').val(),
+    category: $('#article-category').val(),
+    publishedOn: $('#article-published:checked').length ? util.today() : null
+  })
+  // TODO Done: Use our interface to the Handblebars template to put this new article into the DOM:
+  $('#articles').append(articlePreview.toHtml());
+  // TODO Done: Activate the highlighting of any code blocks:
+  $('pre code').each(function(i, block) {
+    hljs.highlightBlock(block);
+  });
+  // TODO Done: Export the new article as JSON, so it's ready to copy/paste into blogArticles.js:
+  $('#export-field').show();
+  $('#article-json').val(JSON.stringify(articlePreview) + ',');
 
-  // TODO: Instantiate an article based on what's in the form fields:
-
-  // TODO: Use our interface to the Handblebars template to put this new article into the DOM:
-
-  // TODO: Activate the highlighting of any code blocks:
-
-  // TODO: Export the new article as JSON, so it's ready to copy/paste into blogArticles.js:
 };
 
 


### PR DESCRIPTION
This assignment took about 1.5 hours to complete.
It was a bit confusing at first what the TODO for adding highlighting block wanted to us to do since the js file itself was just one line and very hard to read. But it was easy once I searched up how to add it in on the highlight.js website.

First I made it so the .tab-content class showed up and hid the export string for JSON. Made an event handler that .on('change') would update the preview of the article when fields were changed. Then I set up a variable which will hold the article objects which will hold the new field entries and append it to the html of the preview. Added the few lines of code for highlight.js that will highlight code blocks taken directly from the highlight.js website. Lastly, made it so the new data is JSON.stringify'd and shown in the little area below for copy and pasting into the JSON file.

This time I worked alone on this assignment.
